### PR TITLE
Permissions Improvement - Data value overriding

### DIFF
--- a/NoItem/src/net/worldoftomorrow/nala/ni/listeners/EventListener.java
+++ b/NoItem/src/net/worldoftomorrow/nala/ni/listeners/EventListener.java
@@ -378,7 +378,7 @@ public class EventListener implements Listener {
 		//NoHave handling
 		if(current != null && Perms.NOHAVE.has(p, current)) {
 			this.notify(p, EventTypes.HAVE, current);
-			p.getInventory().remove(current.getType());
+			p.getInventory().remove(current);
 		}
 	}
 	
@@ -434,8 +434,8 @@ public class EventListener implements Listener {
 			}
 			if(Perms.NOHAVE.has(p, notAllowed)) {
 				this.notify(p, EventTypes.HAVE, notAllowed);
-				p.getInventory().remove(notAllowed.getType());
-			}
+                p.getInventory().remove(notAllowed);
+            }
 		}
 	}
 	
@@ -498,7 +498,7 @@ public class EventListener implements Listener {
 		if(inHand != null && Perms.NOHAVE.has(p, inHand)) {
 			event.setCancelled(true);
 			this.notify(p, EventTypes.HAVE, inHand);
-			p.getInventory().remove(inHand.getType());
+			p.getInventory().remove(inHand);
 		}
 	}
 	


### PR DESCRIPTION
I'm trying to enable 7493:1, but disable 7493 with all other data values.

```
  noitem.nohold.7493.1: false
  noitem.nocraft.7493.1: false
  noitem.nouse.7493.1: false
  noitem.nohave.7493.1: false
  noitem.nohold.7493.all: true
  noitem.nocraft.7493.all: true
  noitem.nouse.7493.all: true
  noitem.nohave.7493.all: true
```

Are the permission nodes I have, but this does not achieve the desired effect. Thoughts on achieving such a goal without listing all 4000 odd possible data values?
